### PR TITLE
Tear down directory after archive created

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,6 @@
+## Description
+<!-- Description of PR--->
+
+
+## Implementation
+<!-- Implementation in bullet points --->

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+on:
+  pull_request:
+    types:
+      - opened
+  push:
+    branches: main
+
+jobs:
+  static-analysis:
+    name: Static analysis
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: poetry
+      - name: Install dependencies
+        run: poetry install 
+      - name: Run black
+        run: poetry run black . --check
+      - name: Run isort
+        run: poetry run isort . --check-only
+      - name: Run flake8
+        run: poetry run flake8 .
+      - name: Run mypy
+        run: poetry run mypy .

--- a/surf_archiver/archiver.py
+++ b/surf_archiver/archiver.py
@@ -60,7 +60,7 @@ class Archiver(AbstractArchiver):
         self,
         date_: Date,
         target_dir: Path,
-    ) -> AsyncGenerator[tuple[Archive], None]:
+    ) -> AsyncGenerator[Archive, None]:
         grouped_files = await self.file_system.list_files_by_date(date_)
 
         experiment_count = len(grouped_files)

--- a/surf_archiver/cli.py
+++ b/surf_archiver/cli.py
@@ -1,9 +1,9 @@
 import asyncio
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID, uuid4
-import logging
 
 import typer
 
@@ -11,7 +11,6 @@ from .config import DEFAULT_CONFIG_PATH, get_config
 from .log import configure_logging
 from .main import amain
 from .utils import Date
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +31,7 @@ def archive(
     config = get_config(config_path)
     if config.log_file:
         configure_logging(job_id, file=config.log_file)
-    
+
     try:
         asyncio.run(amain(Date(date), job_id, config))
     except Exception as err:

--- a/surf_archiver/utils.py
+++ b/surf_archiver/utils.py
@@ -1,5 +1,3 @@
-import asyncio
-from concurrent.futures import Executor
 from datetime import date, datetime
 from pathlib import Path
 from tarfile import TarFile
@@ -22,8 +20,3 @@ def tar(src: Path, target: Path):
     target.parent.mkdir(parents=True, exist_ok=True)
     with TarFile.open(target, "w") as tar:
         tar.add(src, arcname=".")
-
-
-async def atar(src: Path, target: Path, executor: Executor):
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(executor, tar, src, target)


### PR DESCRIPTION
## Description
Ensure that temp directories only persist until a tar file created. After this, ensure that it is deleted.

## Implementation:
- Refactor `_task_iterator` logic
- Lint